### PR TITLE
Allowing request for localhost:3000 by relaxing CORS policy on each end point

### DIFF
--- a/BeerApp/src/main/java/beerapp/dal/ConnectionManager.java
+++ b/BeerApp/src/main/java/beerapp/dal/ConnectionManager.java
@@ -8,8 +8,8 @@ import java.util.Properties;
 public class ConnectionManager {
 
     private final String user = "root";
-    private final String password = "351561449";
-    private final String hostName = "localhost";
+    private final String password = "Password123!";
+    private final String hostName = "127.0.0.1";
     private final int port = 3306;
     private final String schema = "beerapp";
     private final String timezone = "UTC";

--- a/BeerApp/src/main/java/beerapp/servlet/FindBeer.java
+++ b/BeerApp/src/main/java/beerapp/servlet/FindBeer.java
@@ -77,6 +77,10 @@ public class FindBeer extends HttpServlet {
         String json = new Gson().toJson(beers);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
         try {
             response.getWriter().write(json);
         } catch (IOException e) {

--- a/BeerApp/src/main/java/beerapp/servlet/GetTopBeersBySummerReviews.java
+++ b/BeerApp/src/main/java/beerapp/servlet/GetTopBeersBySummerReviews.java
@@ -42,12 +42,15 @@ public class GetTopBeersBySummerReviews extends HttpServlet {
         String json = new Gson().toJson(beerNames);
         resp.setContentType("application/json");
         resp.setCharacterEncoding("UTF-8");
+        resp.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        resp.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        resp.setHeader("Access-Control-Max-Age", "3600");
+        resp.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
         try {
             resp.getWriter().write(json);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-
         // req.setAttribute("beerNames", beerNames);
         // req.getRequestDispatcher("GetTopBeersBySummerReviews.jsp").forward(req, resp);
     }

--- a/BeerApp/src/main/java/beerapp/servlet/GetTopBeersByWinterReviews.java
+++ b/BeerApp/src/main/java/beerapp/servlet/GetTopBeersByWinterReviews.java
@@ -42,6 +42,10 @@ public class GetTopBeersByWinterReviews extends HttpServlet {
         String json = new Gson().toJson(beerNames);
         resp.setContentType("application/json");
         resp.setCharacterEncoding("UTF-8");
+        resp.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        resp.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        resp.setHeader("Access-Control-Max-Age", "3600");
+        resp.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
         try {
             resp.getWriter().write(json);
         } catch (IOException e) {

--- a/BeerApp/src/main/java/beerapp/servlet/GetTopBeersCountsByLager.java
+++ b/BeerApp/src/main/java/beerapp/servlet/GetTopBeersCountsByLager.java
@@ -41,6 +41,10 @@ public class GetTopBeersCountsByLager extends HttpServlet {
         String json = new Gson().toJson(beerNames);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
         try {
             response.getWriter().write(json);
         } catch (IOException e) {

--- a/BeerApp/src/main/java/beerapp/servlet/GetUserRecommendations.java
+++ b/BeerApp/src/main/java/beerapp/servlet/GetUserRecommendations.java
@@ -64,6 +64,10 @@ public class GetUserRecommendations extends HttpServlet {
         String json = new Gson().toJson(top10Recs);
         resp.setCharacterEncoding("UTF-8");
         resp.getWriter().write(json);
+        resp.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        resp.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        resp.setHeader("Access-Control-Max-Age", "3600");
+        resp.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
 
     }
 }

--- a/BeerApp/src/main/java/beerapp/servlet/getTopBeersCountsByAle.java
+++ b/BeerApp/src/main/java/beerapp/servlet/getTopBeersCountsByAle.java
@@ -41,6 +41,10 @@ public class getTopBeersCountsByAle extends HttpServlet {
         String json = new Gson().toJson(beerNames);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
         try {
             response.getWriter().write(json);
         } catch (IOException e) {

--- a/BeerApp/src/main/java/beerapp/servlet/getTopBeersCountsByIPA.java
+++ b/BeerApp/src/main/java/beerapp/servlet/getTopBeersCountsByIPA.java
@@ -41,6 +41,10 @@ public class getTopBeersCountsByIPA extends HttpServlet {
         String json = new Gson().toJson(beerNames);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
         try {
             response.getWriter().write(json);
         } catch (IOException e) {


### PR DESCRIPTION
Basically added
response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
response.setHeader("Access-Control-Max-Age", "3600");
response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Origin");
on each end point, this will allow requests coming in from React app